### PR TITLE
Add "Refresh" capability.

### DIFF
--- a/examples/drivers/genericZWaveCentralSceneDimmer.groovy
+++ b/examples/drivers/genericZWaveCentralSceneDimmer.groovy
@@ -48,7 +48,7 @@ metadata {
         capability "ReleasableButton"
         capability "DoubleTapableButton"
 	capability "Refresh"
-	capability "Polling"
+
 
         command "flash"
         command "refresh"

--- a/examples/drivers/genericZWaveCentralSceneDimmer.groovy
+++ b/examples/drivers/genericZWaveCentralSceneDimmer.groovy
@@ -48,6 +48,7 @@ metadata {
         capability "ReleasableButton"
         capability "DoubleTapableButton"
 	capability "Refresh"
+	capability "Polling"
 
         command "flash"
         command "refresh"

--- a/examples/drivers/genericZWaveCentralSceneDimmer.groovy
+++ b/examples/drivers/genericZWaveCentralSceneDimmer.groovy
@@ -47,6 +47,7 @@ metadata {
         capability "HoldableButton"
         capability "ReleasableButton"
         capability "DoubleTapableButton"
+	capability "Refresh"
 
         command "flash"
         command "refresh"


### PR DESCRIPTION
Declare the "refresh" capability so that dimmers show up in the Rule Machine "Refresh" action.

Similar change should be made to built-in Z-Wave switch and non-centralscene versions of the dimmers / switches.

When Hubitat restarts, Z-Wave device states may be out-of-sync with the Hubitat database states (particularly if a user adjusted the device when Hubitat was restarting). This change is needed so that a user can set Rule Machine to poll all devices on startup, thus ensuring Hubitat has the correct device state on startup

A better approach would be if Hubitat automatically polled all devices on startup and whenever the Z-Wave stack was "disabled" then "Enabled" - this would eliminate user mistakes and confusion about why devices are out-of-sync..